### PR TITLE
fix: usar etiqueta HTML progress para barras de idiomas

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,9 +137,9 @@
   <section id="languages">
     <div class="section-header"><span class="section-num">06</span><h2 class="section-title">Idiomas</h2></div>
     <div class="lang-list">
-      <div class="lang-item"><span class="lang-name">Español</span><div class="lang-bar-bg"><div class="lang-bar-fill lang-fill-full"></div></div><span class="lang-level">Nativo</span></div>
-      <div class="lang-item"><span class="lang-name">Inglés</span><div class="lang-bar-bg"><div class="lang-bar-fill lang-fill-mid"></div></div><span class="lang-level">Intermedio</span></div>
-      <div class="lang-item"><span class="lang-name">Portugués</span><div class="lang-bar-bg"><div class="lang-bar-fill lang-fill-basic"></div></div><span class="lang-level">Básico</span></div>
+      <div class="lang-item"><span class="lang-name">Español</span><progress class="lang-progress" value="100" max="100"></progress><span class="lang-level">Nativo</span></div>
+      <div class="lang-item"><span class="lang-name">Inglés</span><progress class="lang-progress" value="70" max="100"></progress><span class="lang-level">Intermedio</span></div>
+      <div class="lang-item"><span class="lang-name">Portugués</span><progress class="lang-progress" value="30" max="100"></progress><span class="lang-level">Básico</span></div>
     </div>
   </section>
 

--- a/styles.css
+++ b/styles.css
@@ -592,26 +592,32 @@ section.visible {
   letter-spacing: 1px;
 }
 
-.lang-bar-bg {
+/* Progress bar styling */
+.lang-progress {
   flex: 1;
   height: 2px;
-  background: var(--line);
-  border-radius: 2px;
   max-width: 260px;
+  border: none;
+  border-radius: 2px;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
   overflow: hidden;
 }
 
-.lang-bar-fill {
-  height: 100%;
-  background: linear-gradient(90deg, var(--violet-mid), var(--violet-soft));
+.lang-progress::-webkit-progress-bar {
+  background: var(--line);
   border-radius: 2px;
-  transform-origin: left;
-  transform: scaleX(0);
-  transition: transform 1s ease;
 }
 
-.lang-item.visible .lang-bar-fill {
-  transform: scaleX(1);
+.lang-progress::-webkit-progress-value {
+  background: linear-gradient(90deg, var(--violet-mid), var(--violet-soft));
+  border-radius: 2px;
+}
+
+.lang-progress::-moz-progress-bar {
+  background: linear-gradient(90deg, var(--violet-mid), var(--violet-soft));
+  border-radius: 2px;
 }
 
 .lang-level {
@@ -685,12 +691,6 @@ footer {
   letter-spacing: 1px;
 }
 
-/* ===================================
-   Language Fill Classes
-   =================================== */
-.lang-fill-full { width: 100%; }
-.lang-fill-mid { width: 70%; }
-.lang-fill-basic { width: 30%; }
 
 /* ===================================
    Contact Form


### PR DESCRIPTION
Reemplaza los divs personalizados por la etiqueta semantica progress.

- Cambia div.lang-bar-bg > div.lang-bar-fill por progress.lang-progress
- - Actualiza estilos CSS con pseudo-elementos para personalizar la apariencia
- - Elimina clases .lang-fill-full, .lang-fill-mid, .lang-fill-basic