### PR TITLE
fix: usar clases CSS en lugar de selectores de elementos

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,9 +82,9 @@
             </div>
             <div class="bn-footer">
               <div class="bn-stats">
-                <div>Impactos: <span id="bnHits">0</span></div>
-                <div>Agua: <span id="bnMisses">0</span></div>
-                <div>Hundidos: <span id="bnSunk">0</span>/5</div>
+                <div>Impactos: <span class="bn-stat-value" id="bnHits">0</span></div>
+                <div>Agua: <span class="bn-stat-value" id="bnMisses">0</span></div>
+                <div>Hundidos: <span class="bn-stat-value" id="bnSunk">0</span>/5</div>
               </div>
               <button class="bn-btn" id="bnRestart">↺ Nueva partida</button>
             </div>
@@ -99,25 +99,25 @@
     <div class="section-header"><span class="section-num">04</span><h2 class="section-title">Habilidades</h2></div>
     <div class="skills-grid">
       <div class="skill-group">
-        <h4>Lenguajes</h4>
+        <h4 class="skill-group-title">Lenguajes</h4>
         <div class="skill-tags">
           <span class="tag">C</span><span class="tag">Python</span><span class="tag">JavaScript</span><span class="tag">SQL</span><span class="tag">HTML/CSS</span><span class="tag">Java</span>
         </div>
       </div>
       <div class="skill-group">
-        <h4>Bases de datos</h4>
+        <h4 class="skill-group-title">Bases de datos</h4>
         <div class="skill-tags">
           <span class="tag">MySQL</span><span class="tag">SQLite</span><span class="tag">PostgreSQL</span><span class="tag">ERD / Modelado</span>
         </div>
       </div>
       <div class="skill-group">
-        <h4>Herramientas</h4>
+        <h4 class="skill-group-title">Herramientas</h4>
         <div class="skill-tags">
           <span class="tag">Git &amp; GitHub</span><span class="tag">VS Code</span><span class="tag">Pillow</span><span class="tag">Linux</span>
         </div>
       </div>
       <div class="skill-group">
-        <h4>Otras</h4>
+        <h4 class="skill-group-title">Otras</h4>
         <div class="skill-tags">
           <span class="tag">Resolución de problemas</span><span class="tag">Documentación técnica</span><span class="tag">Trabajo autónomo</span>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -466,7 +466,7 @@ section.visible {
   flex-wrap: wrap;
 }
 
-.bn-stats span {
+.bn-stat-value {
   color: var(--violet-mid);
   font-weight: 500;
 }
@@ -501,7 +501,7 @@ section.visible {
   gap: 24px;
 }
 
-.skill-group h4 {
+.skill-group-title {
   font-size: 9px;
   letter-spacing: 3px;
   text-transform: uppercase;


### PR DESCRIPTION
Mejora el rendimiento del CSS. Antes el browser buscaba todos los span/h4 del DOM.

- .bn-stats span -> .bn-stat-value
- - .skill-group h4 -> .skill-group-title